### PR TITLE
Adds missing className prop to Gatsby.Link

### DIFF
--- a/src/Gatsby.re
+++ b/src/Gatsby.re
@@ -12,6 +12,7 @@ module Link = {
     (
       ~children: React.element,
       ~_to: string,
+      ~className: string=?,
       ~style: ReactDOMRe.Style.t=?,
       ~replace: bool=?,
       ~onClick: unit => unit=?,


### PR DESCRIPTION
`className` prop was missing and i needed to style the link in a project i am currently working.